### PR TITLE
Separating lines to prevent line breaks

### DIFF
--- a/src/control.cpp
+++ b/src/control.cpp
@@ -1262,10 +1262,9 @@ int BotControl::menuGraphPage2 (int item) {
          }
       }
       msg ("Nodes: %d - T Points: %d\n"
-         "CT Points: %d - Goal Points: %d\n"
-         "Rescue Points: %d - Camp Points: %d\n"
-         "Block Hostage Points: %d - Sniper Points: %d\n",
-         graph.length (), terrPoints, ctPoints, goalPoints, rescuePoints, campPoints, noHostagePoints, sniperPoints);
+           "CT Points: %d - Goal Points: %d", graph.length (), terrPoints, ctPoints, goalPoints); 
+      msg ("Rescue Points: %d - Camp Points: %d\n"
+           "Block Hostage Points: %d - Sniper Points: %d\n", rescuePoints, campPoints, noHostagePoints, sniperPoints);
 
       showMenu (Menu::NodeMainPage2);
    } break;


### PR DESCRIPTION
Separating lines to prevent line breaks in localization

How it looks like 
Before:
![Снимок экрана (20)](https://user-images.githubusercontent.com/22411953/91655032-ae341480-eacf-11ea-92ee-6ffa4c7d2f34.png)

After:
![Снимок экрана (18)](https://user-images.githubusercontent.com/22411953/91655035-b55b2280-eacf-11ea-9254-23f841309853.png)

